### PR TITLE
Add Arduino Day 2016 (2016-04-02)

### DIFF
--- a/events.yml.txt
+++ b/events.yml.txt
@@ -82,6 +82,12 @@
   when: 2016-03-11 19:00:00 +1
   url: http://torinojs.github.io
 
+20160402:
+  organizer: Arduino.cc
+  title: Arduino Day 2016 - Torino April 2
+  when: 2016-04-02 09:00:00 +1
+  url: https://day.arduino.cc/
+
 20160407:
   organizer: Synesthesia
   title: Droidcon Italy 2016 CONFERENCE - Torino April 7-8


### PR DESCRIPTION
**NOTE**: This event conflicts with planned TorinoTech event 0
See https://github.com/TorinoTech/torinotech.github.io/issues/17

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
